### PR TITLE
Create mail queue in firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "site": "lanfix",
     "public": "public",
     "ignore": [
       "firebase.json",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "jest --silent",
     "lint": "eslint . --quiet",
     "coverage": "npm run test -- --coverage",
-    "monitor-requests": "cd scripts && ./request_monitor.sh",
     "vpn_monitor": "cd scripts && ./vpn_monitor.sh"
   },
   "dependencies": {

--- a/src/notifier/libs/FirebaseHelper.js
+++ b/src/notifier/libs/FirebaseHelper.js
@@ -116,6 +116,18 @@ class FirebaseHelper {
     console.debug(`Found admin emails: ${subs}`);
     return subs;
   }
+
+  async queueEmail({ subject, body, recipients }) {
+    console.debug(
+      `Adding email to queue: ${JSON.stringify({ subject, body, recipients })}`
+    );
+    this.db.collection("email").add({ subject, body, recipients });
+  }
+
+  async removeEmailFromQueue(docId) {
+    console.debug(`Removing email from queue with id: ${docId}`);
+    this.db.collection("email").doc(docId).delete();
+  }
 }
 
 module.exports = FirebaseHelper;

--- a/src/notifier/monitor-emails.js
+++ b/src/notifier/monitor-emails.js
@@ -1,0 +1,36 @@
+const FirebaseHelper = require("./libs/FirebaseHelper");
+const Email = require("./libs/Email");
+
+// Get config location
+const sender = require("../../config/sender.json");
+
+// Get firebase cert location
+const firebaseCert = require("../../config/lanflix-firebase-cert.json");
+const firebase = new FirebaseHelper(firebaseCert);
+
+firebase.db.collection("email").onSnapshot((snapshot) => {
+  snapshot.docChanges().forEach((change) => {
+    try {
+      const data = change.doc.data();
+      console.log(data);
+      const email = new Email();
+      switch (change.type) {
+        case "added":
+          email.setRecipients(data.recipients);
+          email.setSubject(data.subject);
+          email.setBody(data.body);
+          email.sendEmail(sender.name, "gmail", {
+            user: sender.email,
+            pass: sender.password,
+          });
+          break;
+        default:
+          console.warn(`No implementation for ${change.type}`);
+          break;
+      }
+      firebase.removeEmailFromQueue(change.doc.id);
+    } catch (e) {
+      console.error(e);
+    }
+  });
+});


### PR DESCRIPTION
Now instead of having the client scripts trigger the email themselves
a service will run that will check the mail queue. When the client
scripts execute, they will append to the mail queue. This will
increase stability as sometimes the trigger will fail, and the
notification would be lost.